### PR TITLE
Added R 4.2. as supported version. Changed tolerance in test-versus_2…

### DIFF
--- a/.github/workflows/check-full.yaml
+++ b/.github/workflows/check-full.yaml
@@ -18,17 +18,20 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: macOS-10.15,   r: 'oldrel',  pkgext: '.tgz'}
-          - {os: macOS-10.15,   r: 'release', pkgext: '.tgz'}
+          - {os: macOS-latest,   r: 'release', pkgext: '.tgz'}
+          - {os: macOS-latest,   r: 'oldrel',  pkgext: '.tgz'}
+          - {os: macOS-latest,   r: '4.0',     pkgext: '.tgz'}
           # Disccarded due to missing package cpp11 on Mac for R 3.6:
-          #- {os: macOS-10.15,   r: '3.6',     pkgext: '.tgz'}
-          - {os: windows-latest, r: 'oldrel',  pkgext: '.zip'}
+          #- {os: macOS-latest,   r: '3.6',     pkgext: '.tgz'}
           - {os: windows-latest, r: 'release', pkgext: '.zip'}
+          - {os: windows-latest, r: 'oldrel',  pkgext: '.zip'}
+          - {os: windows-latest, r: '4.0',     pkgext: '.zip',    rspm: "https://cloud.r-project.org"}
           # Disccarded due to jsonvalidate 1.3.2 not available on Windoes for R 3.6:
           #- {os: windows-latest, r: '3.6',     pkgext: '.zip',    rspm: "https://cloud.r-project.org"}
-          - {os: ubuntu-18.04,   r: 'release', pkgext: '.tar.gz', rspm: "https://cloud.r-project.org"}
+          - {os: ubuntu-latest,  r: 'release', pkgext: '.tar.gz', rspm: "https://cloud.r-project.org"}
           - {os: ubuntu-18.04,   r: 'oldrel',  pkgext: '.tar.gz', rspm: "https://cloud.r-project.org"}
-          - {os: ubuntu-18.04,   r: '3.6',  pkgext: '.tar.gz', rspm: "https://cloud.r-project.org"}
+          - {os: ubuntu-18.04,   r: '4.0',     pkgext: '.tar.gz', rspm: "https://cloud.r-project.org"}
+          - {os: ubuntu-18.04,   r: '3.6',     pkgext: '.tar.gz', rspm: "https://cloud.r-project.org"}
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: RstoxFramework
-Version: 3.4.1
-Date: 2022-05-13
+Version: 3.4.2
+Date: 2022-05-31
 Title: The Engine of StoX
 Authors@R: c(
   person(given = "Arne Johannes", 
@@ -46,8 +46,8 @@ Imports:
     jsonlite (>= 1.6),
     jsonvalidate (>= 1.3.2),
     methods (>= 3.6.2),
-    RstoxBase (>= 1.9.1),
-    RstoxData (>= 1.6.2),
+    RstoxBase (>= 1.9.2),
+    RstoxData (>= 1.6.3),
     sf (>= 0.9.0),
     sp (>= 1.3.2),
     stringi (>= 1.4.3)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# RstoxFramework v3.4.1 (2022-05-31)
+* Added R 4.2. as supported version.
+* Changed tolerance in test-versus_2.7.R as per slight differences in StratumArea due to move from rgeos to sf in RstoxBase, forced by https://www.r-bloggers.com/2022/04/r-spatial-evolution-retirement-of-rgdal-rgeos-and-maptools/.
+
 # RstoxFramework v3.4.1 (2022-05-13)
 * Fixed bug in Versions.R, which is used by StoX for the tool "Install Rstox packages". The bug was that the package data.table was used but not installed. Also, added support for installing Rstox package binaries built with older R versions than the one installed, allowing for installation of Rstox packages in existing StoX versions even when a new R version is released and installed. In R 4.2. the location of the folder in which user installed packages are saved has changed from the Documents folder to the AppData > Local folder of the user, which is now included in Versions.R.
 * Added the parameters onlyStoxWarnings and onlyStoxErrors to runFunction().

--- a/R/API.R
+++ b/R/API.R
@@ -399,7 +399,7 @@ readModelData <- function(projectPath, modelName = NULL, processName = NULL, ver
                 unlistSep(processNames)
             )
             
-            if(any(invalidProcesses)) {
+            if(length(invalidProcesses)) {
                 warning("The following folders of the output are not present as processes in the project description file, and were discarded from the output:", paste(invalidProcesses, collapse = ", "))
                 outputFiles <- lapply(outputFiles, function(x) x[!names(x) %in% basename(invalidProcesses)])
             }
@@ -489,6 +489,9 @@ readStoxOutputFile <- function(path, emptyStringAsNA = FALSE) {
     else if(tolower(ext) == "nc") {
         stop("NetCDF4 file not yet implemented.")
     }
+    else {
+        stop("Unknown file extension for StoX output file: ", ext, ". Path: ", path, ".")
+    }
     
     if(emptyStringAsNA  && data.table::is.data.table(output)) {
         characterColumns <- names(output)[sapply(output, RstoxData::firstClass) == "character"]
@@ -530,7 +533,7 @@ listOutputfiles <- function(modelPath) {
 
 
 unlistSep <- function(x, sep = "/") {
-    paste(rep(names(processNames), lengths(processNames)), unlist(processNames), sep = sep)
+    paste(rep(names(x), lengths(x)), unlist(x), sep = sep)
 }
 
 

--- a/R/Framework.R
+++ b/R/Framework.R
@@ -3936,7 +3936,8 @@ formatProcessDataOne <-  function(processDataName, processDataOne) {
         
         #sp::proj4string(processDataOne) <- as.character(NA)
         if(length(processDataOne)) {
-            suppressWarnings(sp::proj4string(processDataOne) <- RstoxBase::getRstoxBaseDefinitions("proj4string"))
+            suppressWarnings(sp::proj4string(processDataOne) <- RstoxBase::getRstoxBaseDefinitions("proj4string_longlat"))
+            #suppressWarnings(sp::proj4string(processDataOne) <- RstoxBase::getRstoxBaseDefinitions("proj4string"))
         }
         
         
@@ -3944,7 +3945,8 @@ formatProcessDataOne <-  function(processDataName, processDataOne) {
     }
     # Support for project.RData files, which contained SpatialPolygonsDataFrame for the stratum polygons:
     else if("SpatialPolygonsDataFrame" %in% class(processDataOne)) {
-        suppressWarnings(sp::proj4string(processDataOne) <- RstoxBase::getRstoxBaseDefinitions("proj4string"))
+        suppressWarnings(sp::proj4string(processDataOne) <- RstoxBase::getRstoxBaseDefinitions("proj4string_longlat"))
+        #suppressWarnings(sp::proj4string(processDataOne) <- RstoxBase::getRstoxBaseDefinitions("proj4string"))
         
     }
     # If a data.table:

--- a/R/Interactive.R
+++ b/R/Interactive.R
@@ -469,7 +469,8 @@ addStratum <- function(stratum, projectPath, modelName, processID) {
         stratum <- addCoordsNames(stratum)
         # added by aasmund: Set projection to empty by default, rbind will then work.
         #stratum@proj4string <- sp::CRS()
-        suppressWarnings(sp::proj4string(stratum) <- RstoxBase::getRstoxBaseDefinitions("proj4string"))
+        suppressWarnings(sp::proj4string(stratum) <- RstoxBase::getRstoxBaseDefinitions("proj4string_longlat"))
+        #suppressWarnings(sp::proj4string(stratum) <- RstoxBase::getRstoxBaseDefinitions("proj4string"))
     }
     
     # Add the new strata, but check that the stratum names are not in use:
@@ -584,6 +585,7 @@ removeStratum <- function(stratumName, projectPath, modelName, processID) {
 #' 
 modifyStratum <- function(stratum, projectPath, modelName, processID) {
     
+    browser()
     # Check that the process returns StratumPolygon process data:
     checkDataType("StratumPolygon", projectPath = projectPath, modelName = modelName, processID = processID)
     

--- a/R/Utilities.R
+++ b/R/Utilities.R
@@ -738,7 +738,7 @@ compareProjectToStoredOutputFiles <- function(projectPath, projectPath_original 
     
     # Read the original data:
     #dat_orig <- readModelData(projectPath_original, unlist.models = TRUE)
-    dat_orig <- readModelData(projectPath_original, unlist = 1, emptyStringAsNA = emptyStringAsNA)
+    dat_orig <- readModelData(projectPath_original, unlist = 1, emptyStringAsNA = emptyStringAsNA, verifyFiles = TRUE)
     
     # Compare only those elemens common to the two datasets:
     processNames_present <- all(names(dat_orig) %in% names(dat))

--- a/R/Versions.R
+++ b/R/Versions.R
@@ -1,6 +1,6 @@
 StoxInstallSettings <- list(
     supportedRVersion = c(
-        #"4.2", 
+        "4.2", 
         "4.1", 
         "4.0", 
         "3.6"
@@ -196,7 +196,7 @@ installOfficialRstoxPackagesWithDependencies <- function(
     }
     
     
-    # If Linux, all packages are installed from source. Otherwise a check is made for non-installed binary packages, and an attempt to install from source:
+    # If Linux, all packages are installed from source above. Otherwise a check is made for non-installed binary packages, and an attempt to install from source:
     if (getPlatform(platform) !=  "linux") {
         installed <- utils::installed.packages()[, "Package"]
         missing <- setdiff(toInstall, installed)

--- a/inst/tinytest/test-versus_2.7.R
+++ b/inst/tinytest/test-versus_2.7.R
@@ -27,7 +27,12 @@ si_old <- readStoX2.7OutputFile(file.path(projectPath3_cod, "output", "baseline"
 mab <- merge(ab_new, ab_old, by.x = c("Stratum", "IndividualTotalLength"), by.y = c("SampleUnit", "LengthGroup"), all = TRUE)
 
 # Test:
-tolerance <- 3e-3
+# mab[, summary(abs(Abundance.x - Abundance.y))]
+# From 3.5.0 and onwards:
+# Min.  1st Qu.   Median     Mean  3rd Qu.     Max.     NA's 
+# 0.000000 0.000121 0.000260 0.000282 0.000411 0.001242       25 
+
+tolerance <- 2e-3
 expect_true(mab[, all(abs(Abundance.x - Abundance.y) < tolerance, na.rm =  TRUE)])
 
 
@@ -38,7 +43,11 @@ data.table::setorderv(si_new, c("Stratum", "IndividualTotalLength", "HaulKey", "
 data.table::setorderv(si_old, c("Stratum", "LenGrp", "serialno", "species", "samplenumber", "no"))
 
 # Test:
-tolerance <- 1e-4
+# summary(abs(si_new$Abundance - si_old$Abundance))
+# From 3.5.0 and onwards:
+# Min.   1st Qu.    Median      Mean   3rd Qu.      Max. 
+# 3.190e-09 1.230e-05 2.526e-05 2.555e-05 3.884e-05 1.232e-04 
+tolerance <- 2e-4
 expect_true(all(abs(si_new$Abundance - si_old$Abundance) < tolerance))
 
 

--- a/inst/versions/OfficialRstoxFrameworkVersions.txt
+++ b/inst/versions/OfficialRstoxFrameworkVersions.txt
@@ -60,3 +60,4 @@ StoX	RstoxFramework	Dependencies	Official
 3.4.0	3.4.0	RstoxBase_1.8.0,RstoxData_1.6.0	TRUE
 1.0.1	1.0.1	RstoxBase_0.0.1,RstoxData_0.0.1	FALSE
 3.4.1	3.4.1	RstoxBase_1.9.1,RstoxData_1.6.2	FALSE
+3.4.2	3.4.2	RstoxBase_1.9.2,RstoxData_1.6.3	FALSE


### PR DESCRIPTION
….7.R as per slight differences in StratumArea due to move from rgeos to sf in RstoxBase, forced by https://www.r-bloggers.com/2022/04/r-spatial-evolution-retirement-of-rgdal-rgeos-and-maptools/.