### PR TITLE
Removed from the GUI the warning for EDSUs/Stations detected in more …

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: RstoxFramework
-Version: 3.4.6
-Date: 2022-08-10
+Version: 3.5.0
+Date: 2022-08-12
 Title: The Engine of StoX
 Authors@R: c(
   person(given = "Arne Johannes", 
@@ -46,8 +46,8 @@ Imports:
     jsonlite (>= 1.6),
     jsonvalidate (>= 1.3.2),
     methods (>= 3.6.2),
-    RstoxBase (>= 1.9.8),
-    RstoxData (>= 1.6.8),
+    RstoxBase (>= 1.10.0),
+    RstoxData (>= 1.7.0),
     sf (>= 0.9.0),
     sp (>= 1.3.2),
     stringi (>= 1.4.3)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# RstoxFramework v3.5.0 (2022-08-12)
+* Start of using semantic versioning (https://semver.org/). Before this release the two first version numbers represented the major and minor release number, in accordance with semantic versioning, whereas the third version number identified test versions. The major and minor releases (versions ending with 0.0 or 0) were considered as official versions. From this release and onwards, the third version number will represent patches (bug fixes), and are to be considered equally official as the major and minor releases. In fact, as patches are restricted to fixing bugs and not adding new functionality, the latest patch will be the recommended version.
+
 # RstoxFramework v3.4.6 (2022-08-10)
 * Added truncation to 1000 characters for messages, warnings and errors
 

--- a/inst/versions/OfficialRstoxFrameworkVersions.txt
+++ b/inst/versions/OfficialRstoxFrameworkVersions.txt
@@ -65,3 +65,5 @@ StoX	RstoxFramework	Dependencies	Official
 3.4.4	3.4.4	RstoxBase_1.9.5,RstoxData_1.6.7	FALSE
 3.4.5	3.4.5	RstoxBase_1.9.6,RstoxData_1.6.8	FALSE
 3.4.6	3.4.6	RstoxBase_1.9.8,RstoxData_1.6.8	FALSE
+3.4.7	3.4.7	RstoxBase_1.9.8,RstoxData_1.7.0	FALSE
+3.5.0	3.5.0	RstoxBase_1.10.0,RstoxData_1.7.0	TRUE


### PR DESCRIPTION
…than one stratum. Added warning is all EDSUs included in the AcousticPSU proecss data are missing in the StoxAcousticData, which is an indication of new data in an old project where AcousticPSUs should be re-defined from scratch. Start of using semantic versioning (https://semver.org/). Before this release the two first version numbers represented the major and minor release number, in accordance with semantic versioning, whereas the third version number identified test versions. The major and minor releases (versions ending with 0.0 or 0) were considered as official versions. From this release and onwards, the third version number will represent patches (bug fixes), and are to be considered equally official as the major and minor releases. In fact, as patches are restricted to fixing bugs and not adding new functionality, the latest patch will be the recommended version.